### PR TITLE
Feature: Add regex functionality to hook

### DIFF
--- a/pre_commit_dbt/check_model_parents_database.py
+++ b/pre_commit_dbt/check_model_parents_database.py
@@ -1,4 +1,5 @@
 import argparse
+import re
 from typing import Any
 from typing import Dict
 from typing import Optional
@@ -39,7 +40,7 @@ def check_parents_database(
         )
         for parent in parents:
             db = parent.node.get("database")
-            if (whitelist and db not in whitelist) or db in blacklist:
+            if (whitelist and not any(re.match(regex, db) for regex in whitelist) ) or any(re.match(regex, db) for regex in blacklist):
                 status_code = 1
                 print(
                     f"{model.model_name}: "

--- a/tests/unit/test_check_model_parents_database.py
+++ b/tests/unit/test_check_model_parents_database.py
@@ -20,6 +20,10 @@ TESTS = (  # type: ignore
     (["aa/bb/parent_child.sql"], ["--blacklist", "prod2"], True, 1),
     (["aa/bb/parent_child.sql"], ["--blacklist", "prod"], True, 1),
     (["aa/bb/parent_child.sql"], ["--blacklist", "dev"], True, 0),
+    (["aa/bb/parent_child.sql"], ["--blacklist", "prod[0-9]*"], True, 1),
+    (["aa/bb/parent_child.sql"], ["--blacklist", "abc[0-9]*"], True, 0),
+    (["aa/bb/parent_child.sql"], ["--whitelist", "prod[0-9]*", "core"], True, 0),
+    (["aa/bb/parent_child.sql"], ["--whitelist", "prod[0-9]*"], True, 1),
 )
 
 


### PR DESCRIPTION
## Description
This PR adds regex functionality to the hook `check_model_parents_database`.

### Why?
We use suffixed databases which change depending on the the user and on the ci build number. To allow for these in a whitelist we need to have a regex based whitelist/blacklist.